### PR TITLE
Assignment tooltips

### DIFF
--- a/src/components/PanelParts/Assignment.svelte
+++ b/src/components/PanelParts/Assignment.svelte
@@ -10,6 +10,7 @@
 	<div class="toggle-row">
 		{#each options as assign}
 			<button
+				title={edgesAssignmentNames[assign]}
 				class={$NewEdgeAssignment === assign ? "highlighted" : ""}
 				on:click={() => $NewEdgeAssignment = assign }>{assign}</button>
 		{/each}

--- a/src/tools/assignment/panel.svelte
+++ b/src/tools/assignment/panel.svelte
@@ -26,23 +26,23 @@
 		<div class="flex-column gap">
 			<div class="toggle-row">
 				<button
-					title="Valley / Mountain"
+					title={printable[ASSIGN_SWAP]}
 					highlighted={$AssignType === ASSIGN_SWAP}
 					on:click={() => $AssignType = ASSIGN_SWAP }>V / M</button>
 				<button
-					title="Flat"
+					title={printable[ASSIGN_FLAT]}
 					highlighted={$AssignType === ASSIGN_FLAT}
 					on:click={() => $AssignType = ASSIGN_FLAT }>F</button>
 				<button
-					title="Boundary"
+					title={printable[ASSIGN_BOUNDARY]}
 					highlighted={$AssignType === ASSIGN_BOUNDARY}
 					on:click={() => $AssignType = ASSIGN_BOUNDARY }>B</button>
 				<button
-					title="Cut"
+					title={printable[ASSIGN_CUT]}
 					highlighted={$AssignType === ASSIGN_CUT}
 					on:click={() => $AssignType = ASSIGN_CUT }>C</button>
 				<button
-					title="Unassigned"
+					title={printable[ASSIGN_UNASSIGNED]}
 					highlighted={$AssignType === ASSIGN_UNASSIGNED}
 					on:click={() => $AssignType = ASSIGN_UNASSIGNED }>U</button>
 			</div>

--- a/src/tools/assignment/panel.svelte
+++ b/src/tools/assignment/panel.svelte
@@ -26,18 +26,23 @@
 		<div class="flex-column gap">
 			<div class="toggle-row">
 				<button
+					title="Valley / Mountain"
 					highlighted={$AssignType === ASSIGN_SWAP}
 					on:click={() => $AssignType = ASSIGN_SWAP }>V / M</button>
 				<button
+					title="Flat"
 					highlighted={$AssignType === ASSIGN_FLAT}
 					on:click={() => $AssignType = ASSIGN_FLAT }>F</button>
 				<button
+					title="Boundary"
 					highlighted={$AssignType === ASSIGN_BOUNDARY}
 					on:click={() => $AssignType = ASSIGN_BOUNDARY }>B</button>
 				<button
+					title="Cut"
 					highlighted={$AssignType === ASSIGN_CUT}
 					on:click={() => $AssignType = ASSIGN_CUT }>C</button>
 				<button
+					title="Unassigned"
 					highlighted={$AssignType === ASSIGN_UNASSIGNED}
 					on:click={() => $AssignType = ASSIGN_UNASSIGNED }>U</button>
 			</div>


### PR DESCRIPTION
Wanted to start contributing with some minor things that definitely won't step on your toes! Noticed that I tend to hover over unfamiliar things, which worked great for the tools since they have toolips, but the assignment buttons were not super intuitive and did not have tooltips.

<img width="248" alt="Screenshot 2024-06-17 at 2 44 04 PM" src="https://github.com/rabbit-ear/rabbit-ear-app/assets/9957046/005e2b3c-bdcf-4ace-b68a-edc3df796bf7">

<img width="244" alt="Screenshot 2024-06-17 at 3 04 51 PM" src="https://github.com/rabbit-ear/rabbit-ear-app/assets/9957046/e4aaff00-fe95-4b0a-82c9-3ef4ee25dab5">
